### PR TITLE
Add redirect for Device Tree Usage page

### DIFF
--- a/_data/redirects.csv
+++ b/_data/redirects.csv
@@ -1,2 +1,4 @@
 /software/,https://www.devicetree.org/
 /software,https://www.devicetree.org/
+/Device_Tree_Usage,https://elinux.org/Device_Tree_Usage
+:


### PR DESCRIPTION
Historically http://devicetree.org/Device_Tree_Usage has always pointed
at the very useful Device_Tree_Usage page which currently lives on
elinux.org. Add a redirect for that page.

I think this is the correct way to do this, but I haven't figured out how to test changes to the website locally yet. Let me know if this is handled incorrectly.

Signed-off-by: Grant Likely <grant.likely@arm.com>