### PR TITLE
Fixed DeviceTree blog permalink issue.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,9 @@ url: "https://www.devicetree.org"
 #Github Username
 github_username:  devicetree
 
+# Blog Structure
+permalink: /blog/:title/ 
+
 # Use the Jumbo Jekyll Theme
 theme: jumbo-jekyll-theme
 


### PR DESCRIPTION
Blog permalinks were in an incorrect format.

@pcolmer @shovanuk 