### PR TITLE
Remove Trusted Firmware.org from the Universal Navbar

### DIFF
--- a/_data/universal-nav.yml
+++ b/_data/universal-nav.yml
@@ -17,5 +17,3 @@
       active: true
     - title: OpenDataPlane.org
       url: https://www.opendataplane.org
-    - title: TrustedFirmware.org
-      url: https://www.trustedfirmware.org


### PR DESCRIPTION
Remove Trusted Firmware.org from the Universal Navbar