### PR TITLE
Removing trailing comma to fix lambda redirect issue

### DIFF
--- a/_data/routingrules.json
+++ b/_data/routingrules.json
@@ -1,4 +1,4 @@
 [
     "^/blog(/?|/index.html)$ /news/ [R,L,NC]",
-    "^/blog/(.*)(/?|/index.html)$ /news/ [R,L,NC]",
+    "^/blog/(.*)(/?|/index.html)$ /news/ [R,L,NC]"
 ]


### PR DESCRIPTION
Removing trailing comma to fix lambda redirect issue