### PR TITLE
Update Rob's email and spec to v0.3

### DIFF
--- a/_pages/collaborate/README.md
+++ b/_pages/collaborate/README.md
@@ -76,7 +76,7 @@ This project is licensed under the Apache V2 license. More information can be fo
 
 ## Contributions
 
-Please submit all patches to the mailing list devicetree-spec@vger.kernel.org. Contributions to the Devicetree Specification are managed by the gatekeepers, Grant Likely [grant.likely@secretlab.ca](mailto:grant.likely@secretlab.ca) and Rob Herring [rob.herring@linaro.org](mailto:rob.herring@linaro.org)
+Please submit all patches to the mailing list devicetree-spec@vger.kernel.org. Contributions to the Devicetree Specification are managed by the gatekeepers, Grant Likely [grant.likely@secretlab.ca](mailto:grant.likely@secretlab.ca) and Rob Herring [robh@kernel.org](mailto:robh@kernel.org)
 
 Anyone can contribute to the Devicetree Specification. Contributions to this project should conform to the `Developer Certificate of Origin` as defined at [http://elinux.org/Developer_Certificate_Of_Origin](http://elinux.org/Developer_Certificate_Of_Origin). Commits to this project need to contain the following line to indicate the submitter accepts the DCO:
 

--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@ jumbotron:
 
 If you are looking for the devicetree specification you’ve come to the right place!
 
-## Current release is [v0.2](https://github.com/devicetree-org/devicetree-specification/releases/tag/v0.2)
+## Current release is [v0.3](https://github.com/devicetree-org/devicetree-specification/releases/tag/v0.3)
 
 Devicetree.org is a community effort by many companies and individuals to facilitate the future evolution of the Devicetree Standard.
 


### PR DESCRIPTION
The specification page automatically updates with new releases, can we make the home page always get the latest too?