### PR TITLE
Update spec version and link

### DIFF
--- a/_pages/latest.md
+++ b/_pages/latest.md
@@ -13,7 +13,7 @@ flow:
       - format: text
         text_content:
           text: |-
-            - [Devicetree Specification v0.2 Released](https://www.linaro.org/blog/devicetree-specification-0.2-released/)
+            - [Devicetree Specification v0.3 Released](https://www.devicetree.org/specifications/)
             - [Bud17-313 BoF - Device Tree and Secure Firmware](https://www.linaro.org/blog/bof-device-tree-secure-firmware-bud17-313/)
             - [Introducing devicetree.org](https://www.linaro.org/blog/introducing-devicetree-org/)
 ---


### PR DESCRIPTION
The "latest news" page is pointing at v0.2 when v0.3 has been released. Furthermore, the linked-to page doesn't exist on the Linaro website so changing it to the more general Specifications page.
