### PR TITLE
Small fixes to new devicetree website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# DeviceTree Project Website
+# Devicetree Project Website
 
-This is the git repository for the DeviceTree project website.
+This is the git repository for the Devicetree project website.
 
 ## 🚀 Project Structure
 

--- a/src/components/head/BaseHead.astro
+++ b/src/components/head/BaseHead.astro
@@ -6,7 +6,7 @@ import "../../styles/global.scss";
 const GA_ID = import.meta.env.GA_ID;
 
 const {
-  title = "The DeviceTree Project",
+  title = "The Devicetree Project",
   description = "A devicetree is a data structure for describing hardware.",
   type = "website",
 } = Astro.props;

--- a/src/components/sections/Updates.astro
+++ b/src/components/sections/Updates.astro
@@ -29,7 +29,7 @@ const data_releases = await fetchData();
       data_releases ? (
         <a href={data_releases[0].html_url} class="text-primary">
           <div class="flex flex-row">
-            <span>DeviceTree Specification Release</span>
+            <span>Devicetree Specification Release</span>
             <span>{data_releases[0].tag_name}</span>
           </div>
         </a>
@@ -53,7 +53,7 @@ const data_releases = await fetchData();
         >
           <a href={item.html_url} class="text-primary">
             <div>
-              <span>DeviceTree Specification Release</span>
+              <span>Devicetree Specification Release</span>
               <span>{item.tag_name}</span>
             </div>
           </a>

--- a/src/components/sections/Updates.astro
+++ b/src/components/sections/Updates.astro
@@ -30,14 +30,14 @@ const data_releases = await fetchData();
         <a href={data_releases[0].html_url} class="text-primary">
           <div class="flex flex-row">
             <span>Devicetree Specification Release</span>
-            <span>{data_releases[0].tag_name}</span>
+            <span> {data_releases[0].tag_name}</span>
           </div>
         </a>
       ) : (
         <div>No data available</div>
       )
     }
-    <span class="text-black"> - Released {data_releases[0].created_at}</span>
+    <span class="text-black"> - Released {dateConvertor(data_releases[0].created_at)}</span>
     <span
       class="text-[#2cbe4e] p-[5px] border border-[#2cbe4e] text-xs align-middle relative ml-2"
       >Latest Release</span
@@ -54,7 +54,7 @@ const data_releases = await fetchData();
           <a href={item.html_url} class="text-primary">
             <div>
               <span>Devicetree Specification Release</span>
-              <span>{item.tag_name}</span>
+              <span> {item.tag_name}</span>
             </div>
           </a>
           <span class="text-black mb-6">

--- a/src/content/data/links.yaml
+++ b/src/content/data/links.yaml
@@ -8,7 +8,7 @@
   children:
     - label: OP-TEE
       url: https://www.trustedfirmware.org/projects/op-tee/
-    - label: DeviceTree.org
+    - label: Devicetree.org
       url: https://www.devicetree.org/
     - label: OpenAMP
       url: https://www.openampproject.org/

--- a/src/content/data/links.yaml
+++ b/src/content/data/links.yaml
@@ -2,8 +2,6 @@
   url: https://www.linaro.org/
 - label: Connect
   url: https://www.linaro.org/connect/
-- label: 96Boards
-  url: https://www.96boards.org/
 - label: Projects
   children:
     - label: OP-TEE

--- a/src/content/pages/contact.md
+++ b/src/content/pages/contact.md
@@ -1,7 +1,7 @@
 ---
 title: Contact
 description: >-
-  Please get in touch with us to talk more about DeviceTree and how you can get involved.
+  Please get in touch with us to talk more about Devicetree and how you can get involved.
 slug: "/contact/"
 layout: "../../layouts/Flow.astro"
 hero:
@@ -15,13 +15,13 @@ flow:
         style: text-center px-4 py-5 text-xl
         buttons_content:
           - title: contact@linaro.org
-            url: mailto:contact@linaro.org?subject=DeviceTree.org - /contact/
+            url: mailto:contact@linaro.org?subject=Devicetree.org - /contact/
             style: bg-primary px-2 py-3 border border-b-primary rounded-md text-white mt-8 text-sm font-normal transition ease-in-out delay-150  hover:-translate-y-1 hover:scale-110 hover:bg-[#1a85a1] duration-300
       - component: text
         style: text-center
         text_content:
           text: |-
-            DeviceTree c/o Linaro  
+            Devicetree c/o Linaro  
             Harston Mill  
             Royston Rd   
             Harston  

--- a/src/content/pages/homepage.md
+++ b/src/content/pages/homepage.md
@@ -4,7 +4,7 @@ layout: "../../layouts/Flow.astro"
 slug: ""
 hero:
   inner_image: ../../assets/images/devicetree-icon-white.png
-  title: The DeviceTree Specification
+  title: The Devicetree Specification
   background_image: ../../assets/images/background-image.jpg
   description: >-
     A devicetree is a data structure for describing hardware

--- a/src/content/pages/latest.md
+++ b/src/content/pages/latest.md
@@ -2,7 +2,7 @@
 title: News & Blogs
 slug: /latest/
 description: >
-  Find all DeviceTree related news and blogs here.
+  Find all Devicetree related news and blogs here.
 layout: "../../layouts/Flow.astro"
 hero:
   title: News & Blogs

--- a/src/content/pages/releases.md
+++ b/src/content/pages/releases.md
@@ -3,7 +3,7 @@ layout: ../../layouts/Flow.astro
 title: Releases
 slug: /releases/
 js-package: releases
-keywords: Releases, Device Tree, RoadMap
+keywords: Releases, Devicetree, RoadMap
 hero:
   title: Releases
   background_image: ../../assets/images/background-image.jpg


### PR DESCRIPTION
This makes a few small changes to the website:
- Drops 96Boards links
- Fixes capitalisation of Devicetree
- Fixes formatting of releases

I'm not sure I've done the last change correctly to add a space between the word "Released" and the version tag. Please take a look and let me know if it needs to be done a different.